### PR TITLE
fix: correct the link to navigate to the team page

### DIFF
--- a/beta/src/pages/community/acknowledgements.md
+++ b/beta/src/pages/community/acknowledgements.md
@@ -4,7 +4,7 @@ title: Acknowledgements
 
 ## React {/*react*/}
 
-React was originally created by [Jordan Walke](https://github.com/jordwalke). Today, React has a [dedicated full-time team working on it](/community/team.html), as well as over a thousand [open source contributors](https://github.com/facebook/react/blob/main/AUTHORS). We'd like to recognize a few people who have made significant contributions to React and its documentation in the past and have helped maintain them over the years:
+React was originally created by [Jordan Walke](https://github.com/jordwalke). Today, React has a [dedicated full-time team working on it](/community/meet-the-team.html), as well as over a thousand [open source contributors](https://github.com/facebook/react/blob/main/AUTHORS). We'd like to recognize a few people who have made significant contributions to React and its documentation in the past and have helped maintain them over the years:
 
 * [Almero Steyn](https://github.com/AlmeroSteyn)
 * [Andreas Svensson](https://github.com/syranide)


### PR DESCRIPTION
The original link is incorrect.
![image](https://user-images.githubusercontent.com/34713301/144701217-6cdc95a2-714f-4d81-a7d3-e538559f6171.png)

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
